### PR TITLE
Automatic v3 for hevc

### DIFF
--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -667,6 +667,10 @@ int main(int argc, char** argv)
 			MuxerManager muxerManager(readManager, tsMuxerFactory);
             muxerManager.setAllowStereoMux(fileExt2 == "SSIF" || dt != DT_NONE);
 			muxerManager.openMetaFile(argv[1]);
+			if (dt == DT_BLURAY && muxerManager.getHevcFound()) {
+				LTRACE(LT_WARN, 2, "HEVC stream detected: changing Blu-Ray version to V3.");
+				dt = UHD_BLURAY;
+			}
 			string dstFile = unquoteStr(argv[2]);
 
 			if (dt != DT_NONE)

--- a/tsMuxer/metaDemuxer.cpp
+++ b/tsMuxer/metaDemuxer.cpp
@@ -186,7 +186,7 @@ void METADemuxer::openFile(const string& streamName)
 		string codec = trimStr(params[0]);
 		string codecStreamName = trimStr(params[1]);
 		codec = strToUpperCase ( codec );
-		m_HevcFound = codec.find('HEVC');
+		m_HevcFound = (codec.find("HEVC") == 12);
 		addStream(codec, codecStreamName, addParams);
 		file.readLine(str);
 	}

--- a/tsMuxer/metaDemuxer.cpp
+++ b/tsMuxer/metaDemuxer.cpp
@@ -42,6 +42,7 @@ METADemuxer::METADemuxer(const BufferedReaderManager& readManager):
     m_containerReader(*this, readManager), m_readManager(readManager)
 {
 	m_flushDataMode = false;
+	m_HevcFound = false;
 	m_totalSize = 0;
 	m_lastProgressY = 0;
 	m_lastReadRez = 0;
@@ -185,6 +186,7 @@ void METADemuxer::openFile(const string& streamName)
 		string codec = trimStr(params[0]);
 		string codecStreamName = trimStr(params[1]);
 		codec = strToUpperCase ( codec );
+		m_HevcFound = codec.find('HEVC');
 		addStream(codec, codecStreamName, addParams);
 		file.readLine(str);
 	}

--- a/tsMuxer/metaDemuxer.h
+++ b/tsMuxer/metaDemuxer.h
@@ -173,6 +173,7 @@ public:
     int64_t totalSize() const { return m_totalSize; }
     std::string mplsTrackToFullName(const std::string& mplsFileName, std::string& mplsNum);
     std::string mplsTrackToSSIFName(const std::string& mplsFileName, std::string& mplsNum);
+	bool m_HevcFound;
 private:
 	std::vector<FileListIterator*> m_iterators;
 	int m_lastReadRez;

--- a/tsMuxer/muxerManager.cpp
+++ b/tsMuxer/muxerManager.cpp
@@ -140,7 +140,6 @@ void MuxerManager::checkTrackList(const vector<StreamInfo>& ci)
     bool avcFound = false;
     bool mvcFound = false;
     bool aacFound = false;
-    bool hevcFound = false;
 
     for (vector<StreamInfo>::const_iterator itr = ci.begin(); itr != ci.end(); ++itr) 
     {
@@ -151,14 +150,10 @@ void MuxerManager::checkTrackList(const vector<StreamInfo>& ci)
             mvcFound = true;
         else if (si.m_codec == aacCodecInfo.programName)
             aacFound = true;
-        else if (si.m_codec == hevcCodecInfo.programName)
-            hevcFound = true;
     }
 
     if (m_bluRayMode && aacFound)
         LTRACE(LT_ERROR, 2, "Warning! AAC codec is not standard for BD disks!");
-    if (m_bluRayMode && hevcFound)
-        LTRACE(LT_ERROR, 2, "Warning! HEVC codec is not standard for BD disks!");
 
     if (!avcFound && mvcFound)
         THROW(ERR_INVALID_STREAMS_SELECTED, "Fatal error: MVC depended view track can't be muxed without AVC base view track");

--- a/tsMuxer/muxerManager.h
+++ b/tsMuxer/muxerManager.h
@@ -45,7 +45,7 @@ public:
 
     void parseMuxOpt(const std::string& opts);
     int getTrackCnt() { return (int) m_metaDemuxer.getCodecInfo().size();}
-
+    bool getHevcFound() { return (bool) m_metaDemuxer.m_HevcFound; }
     AbstractMuxer* getMainMuxer();
     AbstractMuxer* getSubMuxer();
     bool isStereoMode() const;


### PR DESCRIPTION
When HEVC stream is detected, this patch allows tsMuxer to automatically changes BD version to V3.
Note that V3 manual selection is still needed for AVC. However it may be more appropriate to include the option as a check box in the "Blu-ray" tab, in lieu of the two radio buttons (UHD Blu-ray ISO, UHD Blu-ray folder) on the main window.