### PR TITLE
Fix suffix NAL

### DIFF
--- a/tsMuxer/hevc.h
+++ b/tsMuxer/hevc.h
@@ -41,7 +41,11 @@ enum HEVCUnitType {
     NAL_FD_NUT     = 38,
     NAL_SEI_PREFIX = 39,
     NAL_SEI_SUFFIX = 40,
-	NAL_DV         = 62,
+    NAL_RSV_NVCL45 = 45,
+    NAL_RSV_NVCL47 = 47,
+    NAL_UNSPEC56   = 56,
+    NAL_DV         = 62,
+    NAL_UNSPEC63   = 63
 };
 
 struct HevcUnit

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -170,6 +170,15 @@ bool HEVCStreamReader::isSlice(int nalType) const
     return (nalType >= NAL_TRAIL_N && nalType <= NAL_RASL_R) || (nalType >= NAL_BLA_W_LP && nalType <= NAL_RSV_IRAP_VCL23);
 }
 
+bool HEVCStreamReader::isSuffix(int nalType) const
+{
+    if (!m_sps || !m_vps || !m_pps)
+        return false;
+    return (nalType == NAL_FD_NUT || nalType == NAL_SEI_SUFFIX || nalType == NAL_RSV_NVCL45 ||
+           (nalType >= NAL_RSV_NVCL45 && nalType <= NAL_RSV_NVCL47) ||
+           (nalType >= NAL_UNSPEC56 && nalType <= NAL_UNSPEC63));
+}
+
 void HEVCStreamReader::incTimings()
 {
     if (m_totalFrameNum++ > 0)
@@ -260,7 +269,7 @@ int HEVCStreamReader::intDecodeNAL(uint8_t* buff)
             }
             sliceFound = true;
         }
-        else { // first non-VCL NAL (AUD, SEI...) following current frame
+        else if (!isSuffix(nalType)) { // first non-VCL prefix NAL (AUD, SEI...) following current frame
             if (sliceFound) {
                 incTimings();
                 m_lastDecodedPos = prevPos;  // next frame started

--- a/tsMuxer/hevcStreamReader.h
+++ b/tsMuxer/hevcStreamReader.h
@@ -31,6 +31,7 @@ protected:
     void onSplitEvent() override { m_firstFileFrame = true; }
 private:
     bool isSlice(int nalType) const;
+    bool isSuffix(int nalType) const;
     void incTimings();
     int toFullPicOrder(HevcSliceHeader* slice, int pic_bits);
     void storeBuffer(MemoryBlock& dst, const uint8_t* data, const uint8_t* dataEnd);


### PR DESCRIPTION
Currently tsMuxer does not detect suffix nals (non VCL nals placed after the VCL nals in the nal unit).
Therefore these nals are placed first in the TS PES, before the AUD or next frame nal.

This patch fixes the above.