### PR TITLE
Correct UHD/DV format

### DIFF
--- a/tsMuxer/ac3Codec.cpp
+++ b/tsMuxer/ac3Codec.cpp
@@ -212,7 +212,7 @@ int AC3Codec::parseHeader(uint8_t* buf, uint8_t* end)
             if (gbc.getBit())
             {
                 int chanLayout = gbc.getBits(16);
-                if (chanLayout & 0x7fe0) // mask standart 5.1 channels
+                if (chanLayout & 0x7fe0) // mask standard 5.1 channels
                     m_extChannelsExists = true;
             }
         }

--- a/tsMuxer/blurayHelper.cpp
+++ b/tsMuxer/blurayHelper.cpp
@@ -111,8 +111,7 @@ bool BlurayHelper::open(const string& dst, DiskType dt, int64_t diskSize, int ex
 
 bool BlurayHelper::createBluRayDirs()
 {
-    if (m_dt == DT_BLURAY || m_dt == UHD_BLURAY) 
-    {
+    if (m_dt == DT_BLURAY) {
         if (m_isoWriter) {
             m_isoWriter->createDir("BDMV/META");
             m_isoWriter->createDir("BDMV/BDJO");
@@ -168,20 +167,26 @@ bool BlurayHelper::writeBluRayFiles(bool usedBlackPL, int mplsNum, int blankNum,
     }
     uint8_t* emptyCommand;
     if (m_dt == DT_BLURAY) {
-        bdMovieObjectData[5] = bdIndexData[5] = '2';
-        fileSize = 0x78;
-    }
-    else if (m_dt == UHD_BLURAY) {
-        bdMovieObjectData[5] = bdIndexData[5] = '3';
-        fileSize = 0x9C; // add 36 bytes for HDR data extension
-        bdIndexData[15] = 0x78; // start address of HDR data extension
-        emptyCommand = bdIndexData + 0x78;
-        memcpy(emptyCommand, "\x00\x00\x00\x20\x00\x00\x00\x18\x00\x00\x00\x01"
-                             "\x00\x03\x00\x01\x00\x00\x00\x18\x00\x00\x00\x0C"
-                             "\x00\x00\x00\x08\x21\x00\x00\x00\x00\x00\x00\x00", 36); // HDR data extension
-        if (*HDR10_metadata & 0x20) bdIndexData[0x94] = 0x51; // 4K flag => 66/100 GB Disk, 109 MB/s Recording_Rate
-        bdIndexData[0x96] = (uint8_t)HDR10_metadata[0]; // HDR flags
-
+        if (V3_flags) {
+            bdMovieObjectData[5] = bdIndexData[5] = '3'; // V3
+            fileSize = 0x9C; // add 36 bytes for UHD data extension
+            bdIndexData[15] = 0x78; // start address of UHD data extension
+            emptyCommand = bdIndexData + 0x78;
+            // UHD data extension
+            memcpy(emptyCommand, "\x00\x00\x00\x20\x00\x00\x00\x18\x00\x00\x00\x01"
+                "\x00\x03\x00\x01\x00\x00\x00\x18\x00\x00\x00\x0C"
+                "\x00\x00\x00\x08\x21\x00\x00\x00\x00\x00\x00\x00", 36);
+            // 4K flag => 66/100 GB Disk, 109 MB/s Recording_Rate
+            if (V3_flags & 0x20) bdIndexData[0x94] = 0x51;
+            // no HDR10 detected => SDR flag
+            if (V3_flags & 0x1e) V3_flags |= 1;
+           // include 4K/HDR/SDR flags
+            bdIndexData[0x96] = (V3_flags & 0x3f);
+        }
+        else { // V2
+            bdMovieObjectData[5] = bdIndexData[5] = '2';
+            fileSize = 0x78;
+        }
     }
     else {
         bdMovieObjectData[5] = bdIndexData[5] = '1';
@@ -237,9 +242,7 @@ bool BlurayHelper::createCLPIFile(TSMuxer* muxer, int clpiNum, bool doLog)
     CLPIParser clpiParser;
     string version_number;
     if (m_dt == DT_BLURAY)
-        memcpy(&clpiParser.version_number, "0200", 5);
-    else if (m_dt == UHD_BLURAY)
-        memcpy(&clpiParser.version_number, "0300", 5);
+        memcpy(&clpiParser.version_number, V3_flags ? "0300" : "0200", 5);
     else
         memcpy(&clpiParser.version_number, "0100", 5);
     clpiParser.clip_stream_type = 1; // AV stream
@@ -252,9 +255,6 @@ bool BlurayHelper::createCLPIFile(TSMuxer* muxer, int clpiNum, bool doLog)
     if (doLog) {
         if (m_dt == DT_BLURAY) {
             LTRACE(LT_INFO, 2, "Creating Blu-ray stream info and seek index");
-        }
-        else if (m_dt == UHD_BLURAY) {
-            LTRACE(LT_INFO, 2, "Creating UHD Blu-ray stream info and seek index");
         }
         else {
             LTRACE(LT_INFO, 2, "Creating AVCHD stream info and seek index");
@@ -283,7 +283,7 @@ bool BlurayHelper::createCLPIFile(TSMuxer* muxer, int clpiNum, bool doLog)
         else
             clpiParser.TS_recording_rate = MAX_MAIN_MUXER_RATE / 8;
         // max rate is 109 mbps for 4K
-        if (*HDR10_metadata & 0x20)
+        if (V3_flags & 0x20)
             clpiParser.TS_recording_rate = (clpiParser.TS_recording_rate * 109) / 48;
         clpiParser.number_of_source_packets = packetCount[i];
         clpiParser.presentation_start_time = firstPts[i] / 2;
@@ -427,9 +427,6 @@ bool BlurayHelper::createMPLSFile(TSMuxer* mainMuxer, TSMuxer* subMuxer,
 
     if (dt == DT_BLURAY) {
         LTRACE(LT_INFO, 2, "Creating Blu-ray playlist");
-    }
-    else if (dt == UHD_BLURAY) {
-        LTRACE(LT_INFO, 2, "Creating UHD Blu-ray playlist");
     }
     else {
         LTRACE(LT_INFO, 2, "Creating AVCHD playlist");

--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -834,17 +834,17 @@ int HevcSeiUnit::deserialize()
 				payloadSize += nbyte;
 			}
 			if (payloadType == 137 && !isHDR10) { // mastering_display_colour_volume
-                HDR10_metadata[1] = m_reader.getBits(32); // display_primaries Green
-                HDR10_metadata[2] = m_reader.getBits(32); // display_primaries Red
-                HDR10_metadata[3] = m_reader.getBits(32); // display_primaries Blue
-                HDR10_metadata[4] = m_reader.getBits(32); // White Point
-                HDR10_metadata[5] = ((m_reader.getBits(32) / 10000) << 16) + m_reader.getBits(32); // max & min display_mastering_luminance
+                HDR10_metadata[0] = m_reader.getBits(32); // display_primaries Green
+                HDR10_metadata[1] = m_reader.getBits(32); // display_primaries Red
+                HDR10_metadata[2] = m_reader.getBits(32); // display_primaries Blue
+                HDR10_metadata[3] = m_reader.getBits(32); // White Point
+                HDR10_metadata[4] = ((m_reader.getBits(32) / 10000) << 16) + m_reader.getBits(32); // max & min display_mastering_luminance
 			}
             else if (payloadType == 144 && !isHDR10) { // content_light_level_info
                 isHDR10 = true;
-                *HDR10_metadata |= 2; // HDR10 flag
+                V3_flags |= 2; // HDR10 flag
                  int maxCLL = m_reader.getBits(32); // maxCLL, maxFALL
-                 if (maxCLL != 0) HDR10_metadata[6] = maxCLL;
+                 if (maxCLL != 0) HDR10_metadata[5] = maxCLL;
             }
 			else if (payloadType == 4 && !isHDR10plus) { // HDR10Plus Metadata
                 m_reader.skipBits(8); // country_code
@@ -856,7 +856,7 @@ int HevcSeiUnit::deserialize()
                 if (application_identifier == 4 && application_version == 1 && num_windows == 1)
                 {
                     isHDR10plus = true;
-                    *HDR10_metadata |= 16; // HDR10plus flag
+                    V3_flags |= 0x10; // HDR10plus flag
                 }
 				payloadSize -= 8;
 				for (int i = 0; i < payloadSize; i++)

--- a/tsMuxer/hevc.h
+++ b/tsMuxer/hevc.h
@@ -3,7 +3,8 @@
 
 #include "nalUnits.h"
 
-extern int HDR10_metadata[7];
+extern int HDR10_metadata[6];
+extern int V3_flags;
 
 enum HevcSliceTypes
 {

--- a/tsMuxer/lpcmStreamReader.cpp
+++ b/tsMuxer/lpcmStreamReader.cpp
@@ -187,7 +187,7 @@ uint32_t LPCMStreamReader::convertWavToPCM(uint8_t* start, uint8_t* end)
 			curPos[2] = tmp;
 		}
 	}
-	// 2. Remap channels to Blu-ray standart
+	// 2. Remap channels to Blu-ray standard
 	if (m_channels == 6) {
 		uint8_t* tmpData = new uint8_t[ch1FullSize];
 		storeChannelData(start, end, 4, tmpData, m_channels); // copy channel 6(LFE) to tmpData
@@ -292,7 +292,7 @@ uint32_t LPCMStreamReader::convertLPCMToWAV(uint8_t* start, uint8_t* end)
 			    curPos[2] = tmp;
 		    }
 	    }
-	    // 2. Remap channels to WAV standart
+	    // 2. Remap channels to WAV standard
 	    if (m_channels == 1) {
 		    removeChannel(start, end, 2, mch);
 	    }
@@ -403,7 +403,7 @@ int LPCMStreamReader::decodeWaveHeader(uint8_t* buff, uint8_t* end)
 			if (!(waveFormatPCMEx->SubFormat == KSDATAFORMAT_SUBTYPE_PCM))
 				THROW (ERR_COMMON, "Unsupported WAVE format. Only PCM audio is supported.");
 		}
-		else if (waveFormatPCMEx->wFormatTag == 0x01) { // standart format
+		else if (waveFormatPCMEx->wFormatTag == 0x01) { // standard format
 			if (m_channels > 2) {
 				if (m_channels == 3) {
 					LTRACE(LT_WARN, 2, "Warning! Multi channels WAVE file for stream " << m_streamIndex << " do not contain channels configuration info. Applying default value: L R LFE");

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -92,8 +92,9 @@ DiskType checkBluRayMux(const char* metaFileName, int& autoChapterLen, vector<do
 			}
 
 			if (str.find("--blu-ray-v3") != string::npos)
-				result =  UHD_BLURAY;
-			else if (str.find("--blu-ray") != string::npos)
+				V3_flags |= 0x80; // flag "V3"
+
+			if (str.find("--blu-ray") != string::npos)
 				result =  DT_BLURAY;
 			else if (str.find("--avchd") != string::npos)
 				result =  DT_AVCHD;
@@ -669,7 +670,7 @@ int main(int argc, char** argv)
 			muxerManager.openMetaFile(argv[1]);
 			if (dt == DT_BLURAY && muxerManager.getHevcFound()) {
 				LTRACE(LT_WARN, 2, "HEVC stream detected: changing Blu-Ray version to V3.");
-				dt = UHD_BLURAY;
+				V3_flags |= 0x80; // flag "V3"
 			}
 			string dstFile = unquoteStr(argv[2]);
 
@@ -683,6 +684,7 @@ int main(int argc, char** argv)
 			}
 			if (muxerManager.getTrackCnt() == 0)
 				THROW(ERR_COMMON, "No tracks selected");
+			//freopen("out.txt", "w", stdout); // ajout jcdr
             muxerManager.doMux(dstFile, dt != DT_NONE ? &blurayHelper : 0);
 			if (dt != DT_NONE) 
 			{

--- a/tsMuxer/mpegVideo.cpp
+++ b/tsMuxer/mpegVideo.cpp
@@ -283,7 +283,7 @@ void MPEGSequenceHeader::setFrameRate(uint8_t* buff, double fps)
 			buff[3] = (buff[3] & 0xf0) + i;
 			return;
 		}
-	THROW(ERR_MPEG2_ERR_FPS, "Can't set fps to value " << fps << ". Only standart fps values allowed for mpeg2 streams.");
+	THROW(ERR_MPEG2_ERR_FPS, "Can't set fps to value " << fps << ". Only standard fps values allowed for mpeg2 streams.");
 }
 
 void MPEGSequenceHeader::setAspectRation(uint8_t* buff, VideoAspectRatio ar)

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -182,7 +182,7 @@ void TSMuxer::intAddStream(const std::string& streamName,
 	int tsStreamIndex = streamIndex + 16;
 	bool isSecondary = codecReader->isSecondary();
 	// 4K flag => change min PCR between two TS packets for TS_Recording_Rate of 13.6 MB/s
-	if (*HDR10_metadata & 0x20) m_minPcrInc = 373;
+	if (V3_flags & 0x20) m_minPcrInc = 373;
 
 	if (codecName[0] == 'V') 
     {
@@ -472,8 +472,8 @@ void TSMuxer::processM2TSPCR(int64_t pcrVal, int64_t pcrGAP)
     int64_t hiResPCR = pcrVal*300 - pcrGAP;
 	uint64_t pcrValDif = hiResPCR - m_prevM2TSPCR; // m2ts pcr clock based on full 27Mhz counter
 	double pcrIncPerFrame = double (pcrValDif + 0.1) / (double) m2tsFrameCnt;
-    // BD player cannot read faster than TS_Recording_Rate
-    if (pcrIncPerFrame < m_minPcrInc) pcrIncPerFrame = m_minPcrInc;
+	// BD player cannot read faster than TS_Recording_Rate
+	if (pcrIncPerFrame < m_minPcrInc) pcrIncPerFrame = m_minPcrInc;
 
 	double curM2TSPCR = m_prevM2TSPCR;
 	uint8_t* curPos;

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -1426,7 +1426,7 @@ int MPLSParser::composeUHD_metadata(uint8_t* buffer, int bufferSize)
 		writer.putBits(32, 0x20);
 		writer.putBits(32, 1 << 24);
 		writer.putBits(32, 1 << 28);
-		for (int i=1; i<7; i++)
+		for (int i = 0; i < 6; i++)
 			writer.putBits(32, HDR10_metadata[i]);
 		writer.flushBits();
 		return writer.getBitsCount() / 8;
@@ -1442,11 +1442,16 @@ int MPLSParser::compose(uint8_t* buffer, int bufferSize, DiskType dt)
     for (int i = 0; i < m_streamInfo.size(); i++)
 	{
 		int stream_coding_type = m_streamInfo[i].stream_coding_type;
-		if (m_streamInfo[i].isSecondary && isVideoStreamType(stream_coding_type))
-        {
-			number_of_SubPaths++;
-            subPath_type = 7; // PIP not fully implemented yet
-        }
+		if (isVideoStreamType(stream_coding_type)) {
+			if (m_streamInfo[i].isSecondary) {
+				number_of_SubPaths++;
+				subPath_type = 7; // PIP not fully implemented yet
+			}
+			else if (m_streamInfo[i].HDR & 4) {
+				number_of_SubPaths++;
+				subPath_type = 10;
+			}
+		}
 	}
 
 	BitStreamWriter writer;
@@ -1455,10 +1460,8 @@ int MPLSParser::compose(uint8_t* buffer, int bufferSize, DiskType dt)
 	std::string type_indicator = "MPLS";
 	std::string version_number;
 	if (dt == DT_BLURAY)
-		version_number = "0200";
-	else if (dt == UHD_BLURAY) 
-		version_number = "0300"; 
-	else 
+		version_number = (V3_flags ? "0300" : "0200");
+	else
 		version_number = "0100";
 	CLPIStreamInfo::writeString(type_indicator.c_str(), writer, 4);
 	CLPIStreamInfo::writeString(version_number.c_str(), writer, 4);
@@ -1485,7 +1488,7 @@ int MPLSParser::compose(uint8_t* buffer, int bufferSize, DiskType dt)
 	while (writer.getBitsCount() % 16 != 0)
 		writer.putBits(8,0);
 	
-	if (number_of_SubPaths > 0 || isDependStreamExist || dt == UHD_BLURAY) 
+	if (number_of_SubPaths > 0 || isDependStreamExist || V3_flags) 
 	{
 		*extDataStartAddr = my_htonl(writer.getBitsCount()/8);
 		uint8_t buffer[1024*4];
@@ -1493,7 +1496,7 @@ int MPLSParser::compose(uint8_t* buffer, int bufferSize, DiskType dt)
 		vector<ExtDataBlockInfo> blockVector;
 
 		//for (int i = 0; i < number_of_SubPaths; ++i)
-        if (number_of_SubPaths > 0)
+        if (number_of_SubPaths > 0 && subPath_type == 7)
 		{
 			int bufferSize = composePip_metadata(buffer, sizeof(buffer), mainStreamInfo.m_index);
 			ExtDataBlockInfo extDataBlock(buffer, bufferSize, 1, 1);
@@ -1513,23 +1516,19 @@ int MPLSParser::compose(uint8_t* buffer, int bufferSize, DiskType dt)
             
         }
 
-		if (dt == UHD_BLURAY)
-		{
+		if (V3_flags) { // V3
 			int bufferSize = composeUHD_metadata(buffer, sizeof(buffer));
 			ExtDataBlockInfo extDataBlock(buffer, bufferSize, 3, 5);
 			blockVector.push_back(extDataBlock);
 		}
 
-
 		composeExtensionData(writer, blockVector);
 		while (writer.getBitsCount() % 16 != 0)
 			writer.putBits(8,0);
 	}
-	
 
 	writer.flushBits();
 	return writer.getBitsCount()/8;
-	
 }
 
 void MPLSParser::AppInfoPlayList(BitStreamReader& reader) 
@@ -1563,8 +1562,11 @@ void MPLSParser::composeAppInfoPlayList(BitStreamWriter& writer)
 	} else {
 		writer.putBits(16, 0); //reserved_for_future_use 16 bslbf
 	}
-	writer.putBits(32,0); //UO_mask_table;
-	writer.putBits(32,0); //UO_mask_table cont;
+	writer.putBits(28, 0); //UO_mask_table;
+	writer.putBits(4, (V3_flags ? 15 : 0)); //UO_mask_table;
+	writer.putBit(0); // reserved
+	writer.putBit(V3_flags ? 15 : 0); //UO_mask_table: SecondaryPGStreamNumberChange
+	writer.putBits(30, 0); //UO_mask_table cont;
 	writer.putBit(0); // PlayList_random_access_flag
 	writer.putBit(1); // audio_mix_app_flag. 0 == no secondary audio, 1- allow secondary audio if exist
 	writer.putBit(0); // lossless_may_bypass_mixer_flag
@@ -2204,8 +2206,11 @@ void MPLSParser::composePlayItem(BitStreamWriter& writer, int playItemNum, std::
 	else
 		writer.putBits(32, OUT_time); //32 uimsbf
 
-	writer.putBits(32,0); //UO_mask_table;
-	writer.putBits(32,0); //UO_mask_table cont;
+	writer.putBits(28, 0); //UO_mask_table;
+	writer.putBits(4, V3_flags ? 15 : 0); //UO_mask_table;
+	writer.putBit(0); // reserved
+	writer.putBit(V3_flags ? 15 : 0); //UO_mask_table: SecondaryPGStreamNumberChange
+	writer.putBits(30, 0); //UO_mask_table cont;
 
 	writer.putBit(PlayItem_random_access_flag); //1 bslbf
 	writer.putBits(7,0); //reserved_for_future_use 7 bslbf
@@ -2608,7 +2613,7 @@ void M2TSStreamInfo::blurayStreamParams(double fps, bool interlaced, int width, 
         *video_format = interlaced ? 2 : 7;
 	else if (width >= 2600) {
 		*video_format = 8;
-		*HDR10_metadata |= 0x20; // 4K flag
+		V3_flags |= 0x20; // 4K flag
 	}
     else if (width >= 1300)
         *video_format = interlaced ? 4 : 6; // as 1920x1080
@@ -2975,9 +2980,7 @@ int MovieObject::compose(uint8_t* buffer, int len, DiskType dt)
 	char type_indicator[5];
 	CLPIStreamInfo::writeString("MOBJ", writer, 4);
 	if (dt == DT_BLURAY)
-		CLPIStreamInfo::writeString("0200", writer, 4);
-	else if (dt == UHD_BLURAY) 
-		CLPIStreamInfo::writeString("0300", writer, 4); 
+		CLPIStreamInfo::writeString(V3_flags ? "0300" : "0200", writer, 4);
 	else
 		CLPIStreamInfo::writeString("0100", writer, 4);
 	writer.putBits(32,0); //uint32_t ExtensionData_start_address  

--- a/tsMuxer/vc1Parser.cpp
+++ b/tsMuxer/vc1Parser.cpp
@@ -112,7 +112,7 @@ void VC1SequenceHeader::setFPS(double value)
 			time_base_num = num_units_in_tick;
 		}
 		else 
-			THROW(ERR_VC1_ERR_FPS, "Can't overwrite stream fps. Non standart fps values not supported for VC-1 streams");
+			THROW(ERR_VC1_ERR_FPS, "Can't overwrite stream fps. Non standard fps values not supported for VC-1 streams");
 		if (time_scale == 24000)
 			nr = 1;
 		else if (time_scale == 25000)
@@ -131,7 +131,7 @@ void VC1SequenceHeader::setFPS(double value)
 		updateBits(m_fpsFieldBitVal + 8, 4, dr);
 	}
 	else
-		THROW(ERR_VC1_ERR_FPS, "Can't overwrite stream fps. Non standart fps values not supported for VC-1 streams");
+		THROW(ERR_VC1_ERR_FPS, "Can't overwrite stream fps. Non standard fps values not supported for VC-1 streams");
 }
 
 int VC1SequenceHeader::decode_sequence_header()

--- a/tsMuxer/vod_common.h
+++ b/tsMuxer/vod_common.h
@@ -94,7 +94,7 @@ struct AVRational{
 
 typedef std::vector<std::pair<int, int> > PriorityDataInfo; // mark some data as priority data
 
-enum DiskType {DT_NONE, DT_BLURAY, UHD_BLURAY, DT_AVCHD};
+enum DiskType {DT_NONE, DT_BLURAY, DT_AVCHD};
 
 uint16_t AV_RB16(const uint8_t* buffer);
 uint32_t AV_RB24(const uint8_t* buffer);


### PR DESCRIPTION
- Separate the V3_flags from the HDR_metadata
- Create Subpath in case of Dolby Vision stream
- Secondary video, audio and PGS flags in Playlist UOTable set to 1 for V3
- Orthographic correction standart to standard