### PR TITLE
Correct UHDFolder Behavior

### DIFF
--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -1495,6 +1495,7 @@ bool TsMuxerWindow::isVideoCropped() {
 bool TsMuxerWindow::isDiskOutput() const {
   return ui.radioButtonAVCHD->isChecked() ||
          ui.radioButtonBluRay->isChecked() ||
+         ui.radioButtonBluRayUHD->isChecked() ||
          ui.radioButtonBluRayISO->isChecked() ||
          ui.radioButtonBluRayISOUHD->isChecked();
 }


### PR DESCRIPTION
radioButtonBluRayUHD was not registered as DiskOption.

This fixes various errors, including lack of chapters with UHD Bluray Folder.