### PR TITLE
Revert on change of ATS #101

### DIFF
--- a/tsMuxer/tsMuxer.h
+++ b/tsMuxer/tsMuxer.h
@@ -187,7 +187,6 @@ private:
     bool m_masterMode;
     bool m_subMode;
     PriorityDataInfo m_priorityData;
-    int m_minPcrInc;
     int64_t m_timeOffset;
     int64_t m_lastSITPCR;
     bool m_canSwithBlock;


### PR DESCRIPTION
Limiting the reading pace of packets to the Bluray Tranfer Rate value actually creates another issue -timegap between two PCR packets create by tsMuxer can be larger than 100ms.
This issue can be worse than the one solved...

I haven't managed to solve this new issue, so for the time being I prefer to revert on the previous merge #101.