### PR TITLE
Set V3 for HEVC

### DIFF
--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -492,6 +492,8 @@ void TsMuxerWindow::onTsMuxerCodecInfoReceived()
                 codecInfo->addSEIMethod = 0;
                 codecInfo->addSPS = false;
             }
+            if (codecInfo->displayName == "HEVC" && !ui->checkBoxV3->isChecked())
+                ui->checkBoxV3->setChecked(true);
             lastTrackID = 0;
         }
         p = procStdOutput[i].indexOf("Stream ID:   ");


### PR DESCRIPTION
This patch allows the option BD-ROM V3 (and the associated --blu-ray-v3 parameter) to be automatically selected before muxing when HEVC is detected.