### PR TITLE
Bug: 3d-plane not detected in specific cases

### DIFF
--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -167,7 +167,7 @@ void detectStreamReader(const char* fileName, MPLSParser* mplsParser, bool isSub
                 // PG stream
                 MPLSStreamInfo streamInfo = mplsParser->getStreamByPID(streams[i].trackID);
                 int pgTrackNum = streamInfo.streamPID - 0x1200;
-                if (pgTrackNum >= 0 && pgTrackNum < pgStreams3D.size())
+                if (pgTrackNum >= 0)
                 {
                     if (streamInfo.offsetId != 0xff)
                     {


### PR DESCRIPTION
Specific case : BD-ROM "The Prodigies 3D"

PGS in M2TS and CLPI: 1200, 1201, 1202, 1203
PGS in MPLS: 1202 (3d-plane=1), 1203 (3d-plane=0)
tsMuxer correctly detects two PGS in MPLS, but incorrectly limits PGS to the first two, 1200 and 1201.
This patch fixes this bug.

Note: This bug was notified by r0lZ, who told me that tsMuxer 2.6.9 was working correctly on the BD. So the addition of `&& pgTrackNum < pgStreams3D.size()` has been done after 2.6.9, but I can't see the reason for this addition.