### PR TITLE
Partial HDMV descriptor when not in bluray mode

### DIFF
--- a/tsMuxer/aacStreamReader.h
+++ b/tsMuxer/aacStreamReader.h
@@ -10,7 +10,7 @@ class AACStreamReader : public SimplePacketizerReader, public AACCodec
    public:
    public:
     AACStreamReader() : SimplePacketizerReader(){};
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override { return 0; }
+    int getTSDescriptor(uint8_t* dstBuff, bool bluRayMode) override { return 0; }
     int getFreq() override { return m_sample_rate; }
     int getChannels() override { return m_channels; }
 

--- a/tsMuxer/abstractStreamReader.h
+++ b/tsMuxer/abstractStreamReader.h
@@ -55,7 +55,7 @@ class AbstractStreamReader : public BaseAbstractStreamReader
     virtual int getTmpBufferSize() { return MAX_AV_PACKET_SIZE; }
     virtual int readPacket(AVPacket& avPacket) = 0;
     virtual int flushPacket(AVPacket& avPacket) = 0;
-    virtual int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) { return 0; }
+    virtual int getTSDescriptor(uint8_t* dstBuff, bool bluRayMode) { return 0; }
     virtual int getStreamHDR() const { return 0; }
     virtual void writePESExtension(PESPacket* pesPacket, const AVPacket& avPacket) {}
     virtual void setStreamIndex(int index) { m_streamIndex = index; }

--- a/tsMuxer/ac3StreamReader.cpp
+++ b/tsMuxer/ac3StreamReader.cpp
@@ -54,7 +54,7 @@ void AC3StreamReader::writePESExtension(PESPacket* pesPacket, const AVPacket& av
     }
 }
 
-int AC3StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int AC3StreamReader::getTSDescriptor(uint8_t* dstBuff, bool bluRayMode)
 {
     {
         AC3Codec::setTestMode(true);

--- a/tsMuxer/ac3StreamReader.h
+++ b/tsMuxer/ac3StreamReader.h
@@ -24,7 +24,7 @@ class AC3StreamReader : public SimplePacketizerReader, public AC3Codec
         m_nextAc3Time = 0;
         m_thdFrameOffset = 0;
     };
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool bluRayMode) override;
     void setNewStyleAudioPES(bool value) { m_useNewStyleAudioPES = value; }
     void setTestMode(bool value) override { AC3Codec::setTestMode(value); }
     int getFreq() override { return AC3Codec::m_sample_rate; }

--- a/tsMuxer/dtsStreamReader.cpp
+++ b/tsMuxer/dtsStreamReader.cpp
@@ -66,7 +66,7 @@ const static int AOUT_CHAN_REVERSESTEREO = 0x40000;
 
 using namespace std;
 
-int DTSStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int DTSStreamReader::getTSDescriptor(uint8_t* dstBuff, bool bluRayMode)
 {
     uint8_t* frame = findFrame(m_buffer, m_bufEnd);
     if (frame == 0)

--- a/tsMuxer/dtsStreamReader.h
+++ b/tsMuxer/dtsStreamReader.h
@@ -45,7 +45,7 @@ class DTSStreamReader : public SimplePacketizerReader
         m_dtsEsChannels = 0;
         m_testMode = false;
     };
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool bluRayMode) override;
     void setDownconvertToDTS(bool value) { m_downconvertToDTS = value; }
     bool getDownconvertToDTS() { return m_downconvertToDTS; }
     DTSHD_SUBTYPE getDTSHDMode() { return m_hdType; }

--- a/tsMuxer/dvbSubStreamReader.cpp
+++ b/tsMuxer/dvbSubStreamReader.cpp
@@ -5,7 +5,7 @@
 const static uint64_t TS_FREQ_TO_INT_FREQ_COEFF = INTERNAL_PTS_FREQ / PCR_FREQUENCY;
 static const int BAD_FRAME = -1;
 
-int DVBSubStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts) { return 0; }
+int DVBSubStreamReader::getTSDescriptor(uint8_t* dstBuff, bool bluRayMode) { return 0; }
 
 uint8_t* DVBSubStreamReader::findFrame(uint8_t* buff, uint8_t* end)
 {

--- a/tsMuxer/dvbSubStreamReader.h
+++ b/tsMuxer/dvbSubStreamReader.h
@@ -9,7 +9,7 @@ class DVBSubStreamReader : public SimplePacketizerReader
 {
    public:
     DVBSubStreamReader() : SimplePacketizerReader(), m_big_offsets(0), m_frameDuration(0), m_firstFrame(true) {}
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool bluRayMode) override;
 
    protected:
     unsigned getHeaderLen() override { return 10; }

--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -437,7 +437,7 @@ int H264StreamReader::writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVP
     return curPos - dstBuffer;
 }
 
-int H264StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int H264StreamReader::getTSDescriptor(uint8_t* dstBuff, bool bluRayMode)
 {
     SliceUnit slice;
     if (m_firstDecodeNal)
@@ -445,7 +445,7 @@ int H264StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
         additionalStreamCheck(m_buffer, m_bufEnd);
         m_firstDecodeNal = false;
     }
-    if (isM2ts)
+    if (bluRayMode)
     {
         // put 'HDMV' registration descriptor
         *dstBuff++ = 0x05;  // registration descriptor tag

--- a/tsMuxer/h264StreamReader.h
+++ b/tsMuxer/h264StreamReader.h
@@ -23,7 +23,7 @@ class H264StreamReader : public MPEGStreamReader
     H264StreamReader();
     ~H264StreamReader() override;
     void setForceLevel(uint8_t value) { m_forcedLevel = value; }
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool bluRayMode) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
     void setH264SPSCont(bool val) { m_h264SPSCont = val; }
 

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -125,12 +125,12 @@ CheckStreamRez HEVCStreamReader::checkStream(uint8_t* buffer, int len)
     return rez;
 }
 
-int HEVCStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int HEVCStreamReader::getTSDescriptor(uint8_t* dstBuff, bool bluRayMode)
 {
     if (m_firstFrame)
         checkStream(m_buffer, m_bufEnd - m_buffer);
 
-    if (isM2ts)
+    if (bluRayMode)
     {
         // put 'HDMV' registration descriptor
         *dstBuff++ = 0x05;  // registration descriptor tag

--- a/tsMuxer/hevcStreamReader.h
+++ b/tsMuxer/hevcStreamReader.h
@@ -12,7 +12,7 @@ class HEVCStreamReader : public MPEGStreamReader
    public:
     HEVCStreamReader();
     ~HEVCStreamReader() override;
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool bluRayMode) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
     bool needSPSForSplit() const override { return false; }
 

--- a/tsMuxer/lpcmStreamReader.cpp
+++ b/tsMuxer/lpcmStreamReader.cpp
@@ -19,7 +19,7 @@ static const uint32_t FMT_FOURCC = FOUR_CC('f', 'm', 't', ' ');
 
 using namespace wave_format;
 
-int LPCMStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int LPCMStreamReader::getTSDescriptor(uint8_t* dstBuff, bool bluRayMode)
 {
     if (m_headerType == htNone)
         if (!detectLPCMType(m_buffer, m_bufEnd - m_buffer))

--- a/tsMuxer/lpcmStreamReader.h
+++ b/tsMuxer/lpcmStreamReader.h
@@ -32,7 +32,7 @@ class LPCMStreamReader : public SimplePacketizerReader
         m_lastChannelRemapPos = 0;
     }
     void setNewStyleAudioPES(bool value) { m_useNewStyleAudioPES = value; }
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool bluRayMode) override;
     int getFreq() override { return m_freq; }
     int getChannels() override { return m_channels; }
     // void setDemuxMode(bool value) {m_demuxMode = value;}

--- a/tsMuxer/mpeg2StreamReader.cpp
+++ b/tsMuxer/mpeg2StreamReader.cpp
@@ -8,7 +8,7 @@
 #include "vodCoreException.h"
 #include "vod_common.h"
 
-int MPEG2StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int MPEG2StreamReader::getTSDescriptor(uint8_t* dstBuff, bool bluRayMode)
 {
     try
     {

--- a/tsMuxer/mpeg2StreamReader.h
+++ b/tsMuxer/mpeg2StreamReader.h
@@ -21,7 +21,7 @@ class MPEG2StreamReader : public MPEGStreamReader
         m_longCodesAllowed = false;
         m_prevFrameDelay = 0;
     }
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool bluRayMode) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
 
     int getStreamWidth() const override { return m_sequence.width; }

--- a/tsMuxer/mpegAudioStreamReader.cpp
+++ b/tsMuxer/mpegAudioStreamReader.cpp
@@ -3,7 +3,7 @@
 
 #include <sstream>
 
-int MpegAudioStreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int MpegAudioStreamReader::getTSDescriptor(uint8_t* dstBuff, bool bluRayMode)
 {
     uint8_t* frame = findFrame(m_buffer, m_bufEnd);
     if (frame == 0)

--- a/tsMuxer/mpegAudioStreamReader.h
+++ b/tsMuxer/mpegAudioStreamReader.h
@@ -9,7 +9,7 @@ class MpegAudioStreamReader : public SimplePacketizerReader, MP3Codec
    public:
     const static uint32_t DTS_HD_PREFIX = 0x64582025;
     MpegAudioStreamReader() : SimplePacketizerReader() {}
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool bluRayMode) override;
     int getLayer() { return m_layer; }
     int getFreq() override { return m_sample_rate; }
     int getChannels() override { return 2; }

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -1181,7 +1181,7 @@ void TSMuxer::buildPMT()
     tsPacket->setPID(DEFAULT_PMT_PID);
     tsPacket->dataExists = 1;
     tsPacket->payloadStart = 1;
-    uint32_t size = m_pmt.serialize(m_pmtBuffer + TSPacket::TS_HEADER_SIZE, 3864, !m_bluRayMode, m_m2tsMode);
+    uint32_t size = m_pmt.serialize(m_pmtBuffer + TSPacket::TS_HEADER_SIZE, 3864, !m_bluRayMode);
     uint8_t* pmtEnd = m_pmtBuffer + TSPacket::TS_HEADER_SIZE + size;
     uint8_t* curPos = m_pmtBuffer + TS_FRAME_SIZE;
     for (; curPos < pmtEnd; curPos += TS_FRAME_SIZE)

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -160,7 +160,7 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
     int descriptorLen = 0;
     uint8_t descrBuffer[1024];
     if (codecReader != 0)
-        descriptorLen = codecReader->getTSDescriptor(descrBuffer, m_m2tsMode);
+        descriptorLen = codecReader->getTSDescriptor(descrBuffer, m_bluRayMode);
 
     if (codecName[0] == 'V')
         m_mainStreamIndex = streamIndex;
@@ -278,11 +278,6 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
             LTRACE(LT_DEBUG, 0, "Muxing fps: " << fps);
         }
     }
-    /*	int descriptorLen = 0;
-            uint8_t descrBuffer[1024];
-            if (codecReader != 0)
-                    descriptorLen = codecReader->getTSDescriptor(descrBuffer);
-    */
 
     if (codecName == "V_MPEG4/ISO/AVC")
     {

--- a/tsMuxer/tsPacket.h
+++ b/tsMuxer/tsPacket.h
@@ -257,7 +257,7 @@ struct TS_program_map_section
     TS_program_map_section();
     bool deserialize(uint8_t* buffer, int buf_size);
     static bool isFullBuff(uint8_t* buffer, int buf_size);
-    uint32_t serialize(uint8_t* buffer, int max_buf_size, bool addLang, bool isM2ts);
+    uint32_t serialize(uint8_t* buffer, int max_buf_size, bool blurayMode);
 
    private:
     void extractDescriptors(uint8_t* curPos, int es_info_len, PMTStreamInfo& pmtInfo);

--- a/tsMuxer/vc1StreamReader.cpp
+++ b/tsMuxer/vc1StreamReader.cpp
@@ -50,7 +50,7 @@ int VC1StreamReader::writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPa
     return (int)(curPtr - dstBuffer);  // afterPesData;
 }
 
-int VC1StreamReader::getTSDescriptor(uint8_t* dstBuff, bool isM2ts)
+int VC1StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
 {
     for (uint8_t* nal = VC1Unit::findNextMarker(m_buffer, m_bufEnd); nal <= m_bufEnd - 32;
          nal = VC1Unit::findNextMarker(nal + 4, m_bufEnd))

--- a/tsMuxer/vc1StreamReader.h
+++ b/tsMuxer/vc1StreamReader.h
@@ -21,7 +21,7 @@ class VC1StreamReader : public MPEGStreamReader
         m_nextFrameAddr = 0;
     }
     ~VC1StreamReader() override {}
-    int getTSDescriptor(uint8_t* dstBuff, bool isM2ts) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
     bool skipNal(uint8_t* nal) override;
     bool needSPSForSplit() const override { return true; }


### PR DESCRIPTION
Change to #203: there is no mpeg-ts descriptor for PGS in T-REC.H.222.0. HDMV descriptor needs to stay in the PMT of the mpeg-ts file. tsMuxer shall use full HDMV descriptors when in bluray mode, and partial HDMV descriptors when not in bluray mode.