### PR TITLE
Add DV profiles 2, 3 and 6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,44 @@
 ## tsMuxeR 2.6.16
+- Fixed a an issue so that Dolby Vision EL stream type is now correct 
+- Fixed a bug with HEVC streams when an HDR10+ SEI payload is too short
+- Fixed a bug where the first 2 frames of the first video track are muxed before anything else
+- Introduced an improvement so Single Track Double Layer files now can properly handled
+- Fixed a bug so that if no MOOF atom is met we stop atom parsing at the next MDAT atom
+- Fixed an issue with HDR flags, so we only set them if an HEVC stream is detected
+- Introduced correct ATSC descriptor for pure EAC3 tracks
+- Introduced correct HDMV TS descriptors for MPEG-2 streams
+- Fixed an issue where Blu-Ray movies will loop rather than stopping after reading
+- Introduced being able to include Dolby Vision descriptors in TS or M2TS mode
+- Fixed the order of streams so that video streams always come first
+- Introduced a GUI option for adjusting PIP transparency
+- Fixed an issue where translated strings appeared in the meta file
+- Fixed a bug in the output paths of the MXE build scripts
+- Ensured we keep M2TS descriptors in TS files (temporary until a long-term solution can be found)
+- Fixed a bug where filenames were being truncated prematurely if there were dots in the filename
+- Introduced putting overnight builds into OBS, to build for various Linux platforms
+- Improved the documentation to fix a broken URL for the test files
+- Introduced a simplification of the method used to play sounds in the GUI
+- Fixed an issue with broken ISO labels when using non-ASCII characters
+- Introduced a refactoring that moved the About page into an external HTML file for the GUI
+- Introduced a code cleanup that removed all usages of std::wstring
+- Fixed an issue with incorrect subtitle spacing on Windows
+- Introduced support for M4V files
+- Fixed issue with subtitle timestamps when joining multiple M2TS files together
+- Fixed incorrect usage of POSIX APIs in Windows builds
+- Fixed a bug with encoding errors when dealing with SSIF files
+- Fixed a bug where we could read over the end of an MP4 file
+- Introduced keeping the track order when multiple video tracks are added
+- Introduced support for reading fragmented MP4 files
+- Introduced support for specific AVC and HEVC descriptors in TS files
+- Introduced support for Dolby Vision atoms in AVC or HEVC streams
+- Introduced a changelog and improved general documentation
+- Fixed an issue with garbled subtitles being displayed
+- Introduced translation support, as well as a full Russian translation of the GUI
+- Introduced getting the HDR10 information from the SPS VUI in HEVC
+- Introduced detection of UTF8 in subtitle files
+- Fixed usage of WinMain, which lead to issues with console output on Windows
+- Introduced converting meta files using active code page if UTF8 fails
+- Improved the documentation for building with Msys2
 - Fixed bugs in the handling of non-ASCII characters in paths on Windows
 - Fixed bugs in subtitles PIDs for BD V3 M2TS with HDR
 - Fixed bug with the display of bitrate and channel numbers for EAC3 and AC3 tracks

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project is for tsMuxer - a transport stream muxer for remuxing/muxing eleme
 EVO/VOB/MPG, MKV/MKA, MP4/MOV, TS, M2TS to TS to M2TS.
 
 Supported video codecs H.264/AVC, H.265/HEVC, VC-1, MPEG2. 
-Supported audio codecs AAC, AC3 / E-AC3(DD+), DTS/ DTS-HD. 
+Supported audio codecs AAC, AC3 / E-AC3(DD+), DTS/ DTS-HD - please note TrueHD must have the AC3 core intact.
 
 Some of the major features include:
 

--- a/tsMuxer/hevc.cpp
+++ b/tsMuxer/hevc.cpp
@@ -271,11 +271,9 @@ HevcSpsUnit::HevcSpsUnit()
       vcl_hrd_parameters_present_flag(false),
       sub_pic_hrd_params_present_flag(false),
       num_short_term_ref_pic_sets(0),
-      colour_primaries(0),
-      transfer_characteristics(0),
-      matrix_coeffs(0),
-      chroma_sample_loc_type_top_field(0),
-      chroma_sample_loc_type_bottom_field(0),
+      colour_primaries(2),
+      transfer_characteristics(2),
+      matrix_coeffs(2),
       num_units_in_tick(0),
       time_scale(0),
       PicSizeInCtbsY_bits(0)
@@ -377,8 +375,8 @@ void HevcSpsUnit::vui_parameters()
     bool chroma_loc_info_present_flag = m_reader.getBit();
     if (chroma_loc_info_present_flag)
     {
-        chroma_sample_loc_type_top_field = extractUEGolombCode();
-        chroma_sample_loc_type_bottom_field = extractUEGolombCode();
+        extractUEGolombCode();  // chroma_sample_loc_type_top_field
+        extractUEGolombCode();  // chroma_sample_loc_type_bottom_field
     }
 
     m_reader.skipBit();  // neutral_chroma_indication_flag u(1)
@@ -848,7 +846,7 @@ int HevcPpsUnit::deserialize()
 }
 
 // ----------------------- HevcHdrUnit ------------------------
-HevcHdrUnit::HevcHdrUnit() : isHDR10(false), isHDR10plus(false), isDVRPU(false), isDVEL(false), DVCompatibility(0) {}
+HevcHdrUnit::HevcHdrUnit() : isHDR10(false), isHDR10plus(false), isDVRPU(false), isDVEL(false) {}
 
 int HevcHdrUnit::deserialize()
 {

--- a/tsMuxer/hevc.h
+++ b/tsMuxer/hevc.h
@@ -160,8 +160,6 @@ struct HevcSpsUnit : public HevcUnitWithProfile
     int colour_primaries;
     int transfer_characteristics;
     int matrix_coeffs;
-    int chroma_sample_loc_type_top_field;
-    int chroma_sample_loc_type_bottom_field;
 
     int num_short_term_ref_pic_sets;
     int num_units_in_tick;
@@ -199,7 +197,6 @@ struct HevcHdrUnit : public HevcUnit
     bool isHDR10plus;
     bool isDVRPU;
     bool isDVEL;
-    int DVCompatibility;
 };
 
 struct HevcSliceHeader : public HevcUnit

--- a/tsMuxer/hevcStreamReader.cpp
+++ b/tsMuxer/hevcStreamReader.cpp
@@ -235,17 +235,30 @@ int HEVCStreamReader::setDoViDescriptor(uint8_t* dstBuff)
 
     int pixelRate = width * getStreamHeight() * getFPS();
 
-    // cf. "DolbyVisionProfilesLevels_v1_3_2_2019_09_16.pdf"
-    int profile = 0;
-    if (!isDVBL)  // dual HEVC track
-        profile = 7;
-    else if (m_hdr->isDVEL)
-        profile = 4;
-    else if (m_sps->colour_primaries == 2 && m_sps->transfer_characteristics == 2 &&
-             m_sps->matrix_coeffs == 2)  // DV IPT color space
-        profile = 5;
-    else
-        profile = 8;
+    // cf. "http://www.dolby.com/us/en/technologies/dolby-vision/dolby-vision-profiles-levels.pdf"
+    int profile;
+    if (m_sps->bit_depth_luma_minus8 == 2)
+    {
+        if (!isDVBL)  // dual HEVC track
+            profile = 7;
+        else if (m_hdr->isDVEL && (V3_flags & HDR10))
+            profile = 6;
+        else if (m_hdr->isDVEL)
+            profile = 4;
+        else if (m_sps->colour_primaries == 2 && m_sps->transfer_characteristics == 2 &&
+                 m_sps->matrix_coeffs == 2)  // DV IPT color space
+            profile = 5;
+        else
+            profile = 8;
+    }
+    else  // 8-bit
+    {
+        if (m_sps->colour_primaries == 2 && m_sps->transfer_characteristics == 2 &&
+            m_sps->matrix_coeffs == 2)  // DV IPT color space
+            profile = 3;
+        else
+            profile = 2;
+    }
 
     int level = 0;
     if (width <= 1280 && pixelRate <= 22118400)

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -305,9 +305,9 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
         // For non-bluray, Dolby Vision track must be stream_type 06 = private data
         if (!m_bluRayMode && tsStreamIndex == 0x1015)
             stream_type = STREAM_TYPE_PRIVATE_DATA;
-        m_pmt.pidList.insert(
-            std::make_pair(tsStreamIndex, PMTStreamInfo(stream_type, tsStreamIndex, descrBuffer,
-                                                        descriptorLen, codecReader, lang, isSecondary)));
+        m_pmt.pidList.insert(std::make_pair(
+            tsStreamIndex,
+            PMTStreamInfo(stream_type, tsStreamIndex, descrBuffer, descriptorLen, codecReader, lang, isSecondary)));
     }
     else if (codecName == "V_MS/VFW/WVC1")
         m_pmt.pidList.insert(

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -302,12 +302,12 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
     else if (codecName == "V_MPEGH/ISO/HEVC")
     {
         int stream_type = STREAM_TYPE_VIDEO_H265;
-        // For non-bluray DV with two HEVC tracks, the DV EL track must be type 06
-        if (!m_bluRayMode && tsStreamIndex == 0x1015 && V3_flags & NON_DV_TRACK)
+        // For non-bluray, Dolby Vision track must be stream_type 06 = private data
+        if (!m_bluRayMode && tsStreamIndex == 0x1015)
             stream_type = STREAM_TYPE_PRIVATE_DATA;
-        m_pmt.pidList.insert(std::make_pair(
-            tsStreamIndex,
-            PMTStreamInfo(stream_type, tsStreamIndex, descrBuffer, descriptorLen, codecReader, lang, isSecondary)));
+        m_pmt.pidList.insert(
+            std::make_pair(tsStreamIndex, PMTStreamInfo(stream_type, tsStreamIndex, descrBuffer,
+                                                        descriptorLen, codecReader, lang, isSecondary)));
     }
     else if (codecName == "V_MS/VFW/WVC1")
         m_pmt.pidList.insert(


### PR DESCRIPTION
So it started with a small correction, but the more I search on DV profiles, the more I find...
From https://forum.blu-ray.com/showpost.php?p=12875562&postcount=645 I have now included DV profiles 2, 3 and 6 (deprecated on new equipment).

Plus As per T-REC-H.265 Annex E.3 VUI Semantics, Colour Primaries, Transfer Characteristics and Matrix Coefficients, when not present in the VUI, should be = 2 (Unspecified) by default. Value 0 is reserved for future use.

Plus code simplification: DVCompatibility is not compulsory in the DoVi descriptor.
Plus change HDMV descriptor to non-HDMV 'HEVC' registration descriptor for HEVC DV tracks.