### PR TITLE
Optional hdmv descriptors

### DIFF
--- a/tsMuxer/aacStreamReader.h
+++ b/tsMuxer/aacStreamReader.h
@@ -10,7 +10,7 @@ class AACStreamReader : public SimplePacketizerReader, public AACCodec
    public:
    public:
     AACStreamReader() : SimplePacketizerReader(){};
-    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override { return 0; }
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors) override { return 0; }
     int getFreq() override { return m_sample_rate; }
     int getChannels() override { return m_channels; }
 

--- a/tsMuxer/abstractStreamReader.h
+++ b/tsMuxer/abstractStreamReader.h
@@ -55,7 +55,7 @@ class AbstractStreamReader : public BaseAbstractStreamReader
     virtual int getTmpBufferSize() { return MAX_AV_PACKET_SIZE; }
     virtual int readPacket(AVPacket& avPacket) = 0;
     virtual int flushPacket(AVPacket& avPacket) = 0;
-    virtual int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) { return 0; }
+    virtual int getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors) { return 0; }
     virtual int getStreamHDR() const { return 0; }
     virtual void writePESExtension(PESPacket* pesPacket, const AVPacket& avPacket) {}
     virtual void setStreamIndex(int index) { m_streamIndex = index; }

--- a/tsMuxer/ac3StreamReader.cpp
+++ b/tsMuxer/ac3StreamReader.cpp
@@ -54,7 +54,7 @@ void AC3StreamReader::writePESExtension(PESPacket* pesPacket, const AVPacket& av
     }
 }
 
-int AC3StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
+int AC3StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors)
 {
     AC3Codec::setTestMode(true);
     uint8_t* frame = findFrame(m_buffer, m_bufEnd);

--- a/tsMuxer/ac3StreamReader.h
+++ b/tsMuxer/ac3StreamReader.h
@@ -24,7 +24,7 @@ class AC3StreamReader : public SimplePacketizerReader, public AC3Codec
         m_nextAc3Time = 0;
         m_thdFrameOffset = 0;
     };
-    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors) override;
     void setNewStyleAudioPES(bool value) { m_useNewStyleAudioPES = value; }
     void setTestMode(bool value) override { AC3Codec::setTestMode(value); }
     int getFreq() override { return AC3Codec::m_sample_rate; }

--- a/tsMuxer/dtsStreamReader.cpp
+++ b/tsMuxer/dtsStreamReader.cpp
@@ -66,7 +66,7 @@ const static int AOUT_CHAN_REVERSESTEREO = 0x40000;
 
 using namespace std;
 
-int DTSStreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
+int DTSStreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors)
 {
     uint8_t* frame = findFrame(m_buffer, m_bufEnd);
     if (frame == 0)

--- a/tsMuxer/dtsStreamReader.h
+++ b/tsMuxer/dtsStreamReader.h
@@ -45,7 +45,7 @@ class DTSStreamReader : public SimplePacketizerReader
         m_dtsEsChannels = 0;
         m_testMode = false;
     };
-    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors) override;
     void setDownconvertToDTS(bool value) { m_downconvertToDTS = value; }
     bool getDownconvertToDTS() { return m_downconvertToDTS; }
     DTSHD_SUBTYPE getDTSHDMode() { return m_hdType; }

--- a/tsMuxer/dvbSubStreamReader.cpp
+++ b/tsMuxer/dvbSubStreamReader.cpp
@@ -5,7 +5,7 @@
 const static uint64_t TS_FREQ_TO_INT_FREQ_COEFF = INTERNAL_PTS_FREQ / PCR_FREQUENCY;
 static const int BAD_FRAME = -1;
 
-int DVBSubStreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode) { return 0; }
+int DVBSubStreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors) { return 0; }
 
 uint8_t* DVBSubStreamReader::findFrame(uint8_t* buff, uint8_t* end)
 {

--- a/tsMuxer/dvbSubStreamReader.h
+++ b/tsMuxer/dvbSubStreamReader.h
@@ -9,7 +9,7 @@ class DVBSubStreamReader : public SimplePacketizerReader
 {
    public:
     DVBSubStreamReader() : SimplePacketizerReader(), m_big_offsets(0), m_frameDuration(0), m_firstFrame(true) {}
-    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors) override;
 
    protected:
     unsigned getHeaderLen() override { return 10; }

--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -437,7 +437,7 @@ int H264StreamReader::writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVP
     return curPos - dstBuffer;
 }
 
-int H264StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
+int H264StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors)
 {
     SliceUnit slice;
     if (m_firstDecodeNal)
@@ -446,23 +446,25 @@ int H264StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
         m_firstDecodeNal = false;
     }
 
-    // put 'HDMV' registration descriptor
-    *dstBuff++ = 0x05;  // registration descriptor tag
-    *dstBuff++ = 8;     // descriptor length
-    memcpy(dstBuff, "HDMV\xff", 5);
-    dstBuff += 5;
+    if (hdmvDescriptors)
+    {
+        // put 'HDMV' registration descriptor
+        *dstBuff++ = 0x05;  // registration descriptor tag
+        *dstBuff++ = 8;     // descriptor length
+        memcpy(dstBuff, "HDMV\xff", 5);
+        dstBuff += 5;
 
-    int video_format, frame_rate_index, aspect_ratio_index;
-    M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(), getStreamAR(),
-                                       &video_format, &frame_rate_index, &aspect_ratio_index);
+        int video_format, frame_rate_index, aspect_ratio_index;
+        M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(), getStreamAR(),
+                                           &video_format, &frame_rate_index, &aspect_ratio_index);
 
-    *dstBuff++ = !m_mvcSubStream ? 0x1b : 0x20;
-    *dstBuff++ = (video_format << 4) + frame_rate_index;
-    *dstBuff++ = (aspect_ratio_index << 4) + 0xf;
+        *dstBuff++ = !m_mvcSubStream ? 0x1b : 0x20;
+        *dstBuff++ = (video_format << 4) + frame_rate_index;
+        *dstBuff++ = (aspect_ratio_index << 4) + 0xf;
 
-    return 10;
+        return 10;
+    }
 
-    // For future use: ATSC desciptor
     for (uint8_t* nal = NALUnit::findNextNAL(m_buffer, m_bufEnd); nal < m_bufEnd - 4;
          nal = NALUnit::findNextNAL(nal, m_bufEnd))
     {

--- a/tsMuxer/h264StreamReader.cpp
+++ b/tsMuxer/h264StreamReader.cpp
@@ -455,8 +455,8 @@ int H264StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hd
         dstBuff += 5;
 
         int video_format, frame_rate_index, aspect_ratio_index;
-        M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(), getStreamAR(),
-                                           &video_format, &frame_rate_index, &aspect_ratio_index);
+        M2TSStreamInfo::blurayStreamParams(getFPS(), getInterlaced(), getStreamWidth(), getStreamHeight(),
+                                           getStreamAR(), &video_format, &frame_rate_index, &aspect_ratio_index);
 
         *dstBuff++ = !m_mvcSubStream ? 0x1b : 0x20;
         *dstBuff++ = (video_format << 4) + frame_rate_index;

--- a/tsMuxer/h264StreamReader.h
+++ b/tsMuxer/h264StreamReader.h
@@ -23,7 +23,7 @@ class H264StreamReader : public MPEGStreamReader
     H264StreamReader();
     ~H264StreamReader() override;
     void setForceLevel(uint8_t value) { m_forcedLevel = value; }
-    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
     void setH264SPSCont(bool val) { m_h264SPSCont = val; }
 

--- a/tsMuxer/hevcStreamReader.h
+++ b/tsMuxer/hevcStreamReader.h
@@ -12,7 +12,7 @@ class HEVCStreamReader : public MPEGStreamReader
    public:
     HEVCStreamReader();
     ~HEVCStreamReader() override;
-    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors) override;
     int setDoViDescriptor(uint8_t* dstBuff);
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
     bool needSPSForSplit() const override { return false; }

--- a/tsMuxer/lpcmStreamReader.cpp
+++ b/tsMuxer/lpcmStreamReader.cpp
@@ -19,7 +19,7 @@ static const uint32_t FMT_FOURCC = FOUR_CC('f', 'm', 't', ' ');
 
 using namespace wave_format;
 
-int LPCMStreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
+int LPCMStreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors)
 {
     if (m_headerType == htNone)
         if (!detectLPCMType(m_buffer, m_bufEnd - m_buffer))

--- a/tsMuxer/lpcmStreamReader.h
+++ b/tsMuxer/lpcmStreamReader.h
@@ -32,7 +32,7 @@ class LPCMStreamReader : public SimplePacketizerReader
         m_lastChannelRemapPos = 0;
     }
     void setNewStyleAudioPES(bool value) { m_useNewStyleAudioPES = value; }
-    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors) override;
     int getFreq() override { return m_freq; }
     int getChannels() override { return m_channels; }
     // void setDemuxMode(bool value) {m_demuxMode = value;}

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -487,8 +487,8 @@ All parameters in this group start with two dashes:
 
 --pcr-on-video-pid  Do not allocate a separate PID for PCR and use the existing
                     video PID.
---new-audio-pes     Use bytes 0xfd instead of 0xbd for AC3, True-HD, DTS and
-                    DTS-HD. Activated automatically for BD muxing.
+--hdmv-descriptors  Use HDMV descriptors instead of ITU-T H.222.0 | ISO/IEC 13818-1
+                    descriptors. Activated automatically for BD muxing.
 --vbr               Use variable bitrate.
 --minbitrate        Sets the lower limit of the VBR bitrate. If the stream has
                     a smaller bitrate, NULL packets will be inserted to

--- a/tsMuxer/mpeg2StreamReader.cpp
+++ b/tsMuxer/mpeg2StreamReader.cpp
@@ -8,7 +8,7 @@
 #include "vodCoreException.h"
 #include "vod_common.h"
 
-int MPEG2StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
+int MPEG2StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors)
 {
     m_sequence.video_format = 5;  // Unspecified video format
     try

--- a/tsMuxer/mpeg2StreamReader.h
+++ b/tsMuxer/mpeg2StreamReader.h
@@ -21,7 +21,7 @@ class MPEG2StreamReader : public MPEGStreamReader
         m_longCodesAllowed = false;
         m_prevFrameDelay = 0;
     }
-    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
 
     int getStreamWidth() const override { return m_sequence.width; }

--- a/tsMuxer/mpegAudioStreamReader.cpp
+++ b/tsMuxer/mpegAudioStreamReader.cpp
@@ -3,7 +3,7 @@
 
 #include <sstream>
 
-int MpegAudioStreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
+int MpegAudioStreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors)
 {
     uint8_t* frame = findFrame(m_buffer, m_bufEnd);
     if (frame == 0)

--- a/tsMuxer/mpegAudioStreamReader.h
+++ b/tsMuxer/mpegAudioStreamReader.h
@@ -9,7 +9,7 @@ class MpegAudioStreamReader : public SimplePacketizerReader, MP3Codec
    public:
     const static uint32_t DTS_HD_PREFIX = 0x64582025;
     MpegAudioStreamReader() : SimplePacketizerReader() {}
-    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors) override;
     int getLayer() { return m_layer; }
     int getFreq() override { return m_sample_rate; }
     int getChannels() override { return 2; }

--- a/tsMuxer/singleFileMuxer.cpp
+++ b/tsMuxer/singleFileMuxer.cpp
@@ -40,7 +40,7 @@ void SingleFileMuxer::intAddStream(const std::string& streamName, const std::str
 {
     codecReader->setDemuxMode(true);
     uint8_t descrBuffer[188];
-    int descriptorLen = codecReader->getTSDescriptor(descrBuffer, true);
+    int descriptorLen = codecReader->getTSDescriptor(descrBuffer, true, true);
     string fileExt = "track";
     if (codecName == "A_AC3")
         fileExt = ".ac3";

--- a/tsMuxer/tsMuxer.cpp
+++ b/tsMuxer/tsMuxer.cpp
@@ -110,6 +110,7 @@ TSMuxer::TSMuxer(MuxerManager* owner) : AbstractMuxer(owner)
     m_splitSize = m_splitDuration = 0;
     m_curFileNum = 0;
     m_bluRayMode = false;
+    m_hdmvDescriptors = false;
     m_lastGopNullCnt = 0;
     m_outBufLen = 0;
     m_pesData.reserve(1024 * 128);
@@ -165,7 +166,7 @@ void TSMuxer::intAddStream(const std::string& streamName, const std::string& cod
     int descriptorLen = 0;
     uint8_t descrBuffer[1024];
     if (codecReader != 0)
-        descriptorLen = codecReader->getTSDescriptor(descrBuffer, m_bluRayMode);
+        descriptorLen = codecReader->getTSDescriptor(descrBuffer, m_bluRayMode, m_hdmvDescriptors);
 
     if (codecName[0] == 'V')
         m_mainStreamIndex = streamIndex;
@@ -1188,7 +1189,7 @@ void TSMuxer::buildPMT()
     tsPacket->setPID(DEFAULT_PMT_PID);
     tsPacket->dataExists = 1;
     tsPacket->payloadStart = 1;
-    uint32_t size = m_pmt.serialize(m_pmtBuffer + TSPacket::TS_HEADER_SIZE, 3864, m_bluRayMode);
+    uint32_t size = m_pmt.serialize(m_pmtBuffer + TSPacket::TS_HEADER_SIZE, 3864, m_bluRayMode, m_hdmvDescriptors);
     uint8_t* pmtEnd = m_pmtBuffer + TSPacket::TS_HEADER_SIZE + size;
     uint8_t* curPos = m_pmtBuffer + TS_FRAME_SIZE;
     for (; curPos < pmtEnd; curPos += TS_FRAME_SIZE)
@@ -1373,8 +1374,11 @@ void TSMuxer::parseMuxOpt(const std::string& opts)
             continue;
         if (paramPair[0] == "--pcr-on-video-pid")
             setPCROnVideoPID(true);
-        else if (paramPair[0] == "--new-audio-pes")
+        else if (paramPair[0] == "--hdmv-descriptors")
+        {
             setNewStyleAudioPES(true);
+            m_hdmvDescriptors = true;
+        }
         else if (paramPair[0] == "--bitrate" && paramPair.size() > 1)
         {
             setMaxBitrate(strToDouble(paramPair[1].c_str()) * 1000.0);

--- a/tsMuxer/tsMuxer.h
+++ b/tsMuxer/tsMuxer.h
@@ -132,6 +132,7 @@ class TSMuxer : public AbstractMuxer
     bool m_m2tsMode;
     int m_curFileNum;
     bool m_bluRayMode;
+    bool m_hdmvDescriptors;
     uint64_t m_splitSize;
     uint64_t m_splitDuration;
 

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -374,7 +374,7 @@ void TS_program_map_section::extractDescriptors(uint8_t* curPos, int es_info_len
     }
 }
 
-uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bool blurayMode)
+uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bool blurayMode, bool hdmvDescriptors)
 {
     buffer[0] = 0;
     buffer++;
@@ -401,15 +401,18 @@ uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bo
     bitWriter.putBits(12, 0);  // program info len
     int beforeCount2 = bitWriter.getBitsCount() / 8;
 
-    // put 'HDMV' registration descriptor
-    bitWriter.putBits(8, 0x05);
-    bitWriter.putBits(8, 0x04);
-    bitWriter.putBits(32, 0x48444d56);
+    if (hdmvDescriptors)
+    {
+        // put 'HDMV' registration descriptor
+        bitWriter.putBits(8, 0x05);
+        bitWriter.putBits(8, 0x04);
+        bitWriter.putBits(32, 0x48444d56);
 
-    // put DTCP descriptor
-    bitWriter.putBits(8, 0x88);
-    bitWriter.putBits(8, 0x04);
-    bitWriter.putBits(32, 0x0ffffcfc);
+        // put DTCP descriptor
+        bitWriter.putBits(8, 0x88);
+        bitWriter.putBits(8, 0x04);
+        bitWriter.putBits(32, 0x0ffffcfc);
+    }
 
     if (casPID)
     {

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -454,6 +454,9 @@ uint32_t TS_program_map_section::serialize(uint8_t* buffer, int max_buf_size, bo
 
     for (PIDListMap::const_iterator itr = pidList.begin(); itr != pidList.end(); ++itr)
     {
+        if (itr->second.m_streamType == 0x90 && !hdmvDescriptors)
+            LTRACE(LT_WARN, 0, "Warning: PGS might not work without HDMV descriptors.");
+
         bitWriter.putBits(8, itr->second.m_streamType);
         bitWriter.putBits(3, 7);  // reserved
         bitWriter.putBits(13, itr->second.m_pid);

--- a/tsMuxer/tsPacket.h
+++ b/tsMuxer/tsPacket.h
@@ -257,7 +257,7 @@ struct TS_program_map_section
     TS_program_map_section();
     bool deserialize(uint8_t* buffer, int buf_size);
     static bool isFullBuff(uint8_t* buffer, int buf_size);
-    uint32_t serialize(uint8_t* buffer, int max_buf_size, bool blurayMode);
+    uint32_t serialize(uint8_t* buffer, int max_buf_size, bool blurayMode, bool hdmvDescriptors);
 
    private:
     void extractDescriptors(uint8_t* curPos, int es_info_len, PMTStreamInfo& pmtInfo);

--- a/tsMuxer/vc1StreamReader.cpp
+++ b/tsMuxer/vc1StreamReader.cpp
@@ -50,7 +50,7 @@ int VC1StreamReader::writeAdditionData(uint8_t* dstBuffer, uint8_t* dstEnd, AVPa
     return (int)(curPtr - dstBuffer);  // afterPesData;
 }
 
-int VC1StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode)
+int VC1StreamReader::getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors)
 {
     for (uint8_t* nal = VC1Unit::findNextMarker(m_buffer, m_bufEnd); nal <= m_bufEnd - 32;
          nal = VC1Unit::findNextMarker(nal + 4, m_bufEnd))

--- a/tsMuxer/vc1StreamReader.h
+++ b/tsMuxer/vc1StreamReader.h
@@ -21,7 +21,7 @@ class VC1StreamReader : public MPEGStreamReader
         m_nextFrameAddr = 0;
     }
     ~VC1StreamReader() override {}
-    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode) override;
+    int getTSDescriptor(uint8_t* dstBuff, bool blurayMode, bool hdmvDescriptors) override;
     virtual CheckStreamRez checkStream(uint8_t* buffer, int len);
     bool skipNal(uint8_t* nal) override;
     bool needSPSForSplit() const override { return true; }

--- a/tsMuxerGUI/tsmuxerwindow.cpp
+++ b/tsMuxerGUI/tsmuxerwindow.cpp
@@ -1552,7 +1552,7 @@ QString TsMuxerWindow::getMuxOpts()
 {
     QString rez = "MUXOPT --no-pcr-on-video-pid ";
     if (ui->checkBoxNewAudioPes->isChecked())
-        rez += "--new-audio-pes ";
+        rez += "--hdmv-descriptors ";
     if (ui->radioButtonBluRay->isChecked())
         rez += (ui->checkBoxV3->isChecked() ? "--blu-ray-v3 " : "--blu-ray ");
     else if (ui->radioButtonBluRayISO->isChecked())
@@ -2349,6 +2349,8 @@ void TsMuxerWindow::RadioButtonMuxClick()
         ui->buttonMux->setText(tr("Sta&rt demuxing"));
     else
         ui->buttonMux->setText(tr("Sta&rt muxing"));
+    ui->checkBoxNewAudioPes->setChecked(!ui->radioButtonTS->isChecked());
+    ui->checkBoxNewAudioPes->setEnabled(ui->radioButtonTS->isChecked() || ui->radioButtonM2TS->isChecked());
     outFileNameDisableChange = true;
     if (ui->radioButtonBluRay->isChecked() || ui->radioButtonDemux->isChecked() || ui->radioButtonAVCHD->isChecked())
     {


### PR DESCRIPTION
Changes the behavior of the "Generate HDMV compatible TS" checkbox in the General tab:
- For "TS muxing" mode, the box is unchecked by default;
- For "M2TS muxing" mode, the box is checked by default;
- For all other (Blu-ray and demux) modes, the box is greyed out with the option checked by default.