### PR TITLE
Detect the tracks from the longest playlist

### DIFF
--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -2525,14 +2525,15 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
     number_of_DolbyVision_video_stream_entries = reader.getBits(8);   // 8 uimsbf
     reader.skipBits(32);                                              // reserved_for_future_use 32 bslbf
 
+    std::vector<MPLSStreamInfo> streamInfos;
+
     for (int primary_video_stream_id = 0; primary_video_stream_id < number_of_primary_video_stream_entries;
          primary_video_stream_id++)
     {
         MPLSStreamInfo streamInfo;
         streamInfo.parseStreamEntry(reader);
         streamInfo.parseStreamAttributes(reader);
-        if (PlayItem_id == 0)
-            m_streamInfo.push_back(streamInfo);
+        streamInfos.push_back(streamInfo);
     }
     for (int primary_audio_stream_id = 0; primary_audio_stream_id < number_of_primary_audio_stream_entries;
          primary_audio_stream_id++)
@@ -2540,8 +2541,7 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
         MPLSStreamInfo streamInfo;
         streamInfo.parseStreamEntry(reader);
         streamInfo.parseStreamAttributes(reader);
-        if (PlayItem_id == 0)
-            m_streamInfo.push_back(streamInfo);
+        streamInfos.push_back(streamInfo);
     }
 
     for (int PG_textST_stream_id = 0;
@@ -2551,8 +2551,7 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
         MPLSStreamInfo streamInfo;
         streamInfo.parseStreamEntry(reader);
         streamInfo.parseStreamAttributes(reader);
-        if (PlayItem_id == 0)
-            m_streamInfo.push_back(streamInfo);
+        streamInfos.push_back(streamInfo);
     }
 
     for (int IG_stream_id = 0; IG_stream_id < number_of_IG_stream_entries; IG_stream_id++)
@@ -2560,8 +2559,7 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
         MPLSStreamInfo streamInfo;
         streamInfo.parseStreamEntry(reader);
         streamInfo.parseStreamAttributes(reader);
-        if (PlayItem_id == 0)
-            m_streamInfo.push_back(streamInfo);
+        streamInfos.push_back(streamInfo);
     }
 
     for (int secondary_audio_stream_id = 0; secondary_audio_stream_id < number_of_secondary_audio_stream_entries;
@@ -2571,8 +2569,7 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
         streamInfo.isSecondary = true;
         streamInfo.parseStreamEntry(reader);
         streamInfo.parseStreamAttributes(reader);
-        if (PlayItem_id == 0)
-            m_streamInfo.push_back(streamInfo);
+        streamInfos.push_back(streamInfo);
 
         // comb_info_Secondary_audio_Primary_audio(){
         int number_of_primary_audio_ref_entries = reader.getBits(8);  // 8 uimsbf
@@ -2594,8 +2591,7 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
         streamInfo.isSecondary = true;
         streamInfo.parseStreamEntry(reader);
         streamInfo.parseStreamAttributes(reader);
-        if (PlayItem_id == 0)
-            m_streamInfo.push_back(streamInfo);
+        streamInfos.push_back(streamInfo);
 
         // comb_info_Secondary_video_Secondary_audio(){
         int number_of_secondary_audio_ref_entries = reader.getBits(8);  // 8 uimsbf
@@ -2628,8 +2624,13 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
         MPLSStreamInfo streamInfo;
         streamInfo.parseStreamEntry(reader);
         streamInfo.parseStreamAttributes(reader);
-        if (PlayItem_id == 0)
-            m_streamInfo.push_back(streamInfo);
+        streamInfos.push_back(streamInfo);
+    }
+
+    if (streamInfos.size() > m_streamInfo.size())
+    {
+        m_streamInfo = streamInfos;
+        m_playItem = PlayItem_id;
     }
 }
 

--- a/tsMuxer/tsPacket.h
+++ b/tsMuxer/tsPacket.h
@@ -529,6 +529,7 @@ struct MPLSParser
     bool is_seamless_angle_change;
 
     int m_chapterLen;
+    int m_playItem;
 
     uint32_t IN_time;
     uint32_t OUT_time;


### PR DESCRIPTION
tsMuxer currently detects the tracks from the first playlist/clpi/m2ts of the mpls.
The subsequent playlists can have additional audio or subtitle tracks which are not in the first playlist.
This commit allows tsMuxer to take the tracks from the playlist which has the most tracks, and not from the first playlist only.