### PR TITLE
Pre-check for Frame Depth

### DIFF
--- a/tsMuxer/hevcStreamReader.h
+++ b/tsMuxer/hevcStreamReader.h
@@ -37,7 +37,7 @@ class HEVCStreamReader : public MPEGStreamReader
    private:
     bool isSlice(int nalType) const;
     bool isSuffix(int nalType) const;
-    void incTimings();
+    void checkFrameDepth();
     int toFullPicOrder(HevcSliceHeader* slice, int pic_bits);
     void storeBuffer(MemoryBlock& dst, const uint8_t* data, const uint8_t* dataEnd);
     uint8_t* writeBuffer(MemoryBlock& srcData, uint8_t* dstBuffer, uint8_t* dstEnd);

--- a/tsMuxer/main.cpp
+++ b/tsMuxer/main.cpp
@@ -616,7 +616,7 @@ int main(int argc, char** argv)
                 bool switchToSsif = false;
                 if (mplsParser.m_playItems.size() > 0)
                 {
-                    MPLSPlayItem& item = mplsParser.m_playItems[mplsParser.m_playItem];
+                    MPLSPlayItem& item = mplsParser.m_playItems[0];
                     string itemName = streamDir + item.fileName + mediaExt;
                     if (fileExists(itemName))
                     {

--- a/tsMuxer/tsPacket.cpp
+++ b/tsMuxer/tsPacket.cpp
@@ -1296,12 +1296,7 @@ int CLPIParser::compose(uint8_t* buffer, int bufferSize)
 // -------------------------- MPLSParser ----------------------------
 
 MPLSParser::MPLSParser()
-    : m_chapterLen(0),
-      m_playItem(0),
-      number_of_SubPaths(0),
-      m_m2tsOffset(0),
-      isDependStreamExist(false),
-      mvc_base_view_r(false)
+    : m_chapterLen(0), number_of_SubPaths(0), m_m2tsOffset(0), isDependStreamExist(false), mvc_base_view_r(false)
 {
     number_of_primary_video_stream_entries = 0;
     number_of_primary_audio_stream_entries = 0;
@@ -2530,15 +2525,14 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
     number_of_DolbyVision_video_stream_entries = reader.getBits(8);   // 8 uimsbf
     reader.skipBits(32);                                              // reserved_for_future_use 32 bslbf
 
-    std::vector<MPLSStreamInfo> streamInfos;
-
     for (int primary_video_stream_id = 0; primary_video_stream_id < number_of_primary_video_stream_entries;
          primary_video_stream_id++)
     {
         MPLSStreamInfo streamInfo;
         streamInfo.parseStreamEntry(reader);
         streamInfo.parseStreamAttributes(reader);
-        streamInfos.push_back(streamInfo);
+        if (PlayItem_id == 0)
+            m_streamInfo.push_back(streamInfo);
     }
     for (int primary_audio_stream_id = 0; primary_audio_stream_id < number_of_primary_audio_stream_entries;
          primary_audio_stream_id++)
@@ -2546,7 +2540,8 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
         MPLSStreamInfo streamInfo;
         streamInfo.parseStreamEntry(reader);
         streamInfo.parseStreamAttributes(reader);
-        streamInfos.push_back(streamInfo);
+        if (PlayItem_id == 0)
+            m_streamInfo.push_back(streamInfo);
     }
 
     for (int PG_textST_stream_id = 0;
@@ -2556,7 +2551,8 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
         MPLSStreamInfo streamInfo;
         streamInfo.parseStreamEntry(reader);
         streamInfo.parseStreamAttributes(reader);
-        streamInfos.push_back(streamInfo);
+        if (PlayItem_id == 0)
+            m_streamInfo.push_back(streamInfo);
     }
 
     for (int IG_stream_id = 0; IG_stream_id < number_of_IG_stream_entries; IG_stream_id++)
@@ -2564,7 +2560,8 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
         MPLSStreamInfo streamInfo;
         streamInfo.parseStreamEntry(reader);
         streamInfo.parseStreamAttributes(reader);
-        streamInfos.push_back(streamInfo);
+        if (PlayItem_id == 0)
+            m_streamInfo.push_back(streamInfo);
     }
 
     for (int secondary_audio_stream_id = 0; secondary_audio_stream_id < number_of_secondary_audio_stream_entries;
@@ -2574,7 +2571,8 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
         streamInfo.isSecondary = true;
         streamInfo.parseStreamEntry(reader);
         streamInfo.parseStreamAttributes(reader);
-        streamInfos.push_back(streamInfo);
+        if (PlayItem_id == 0)
+            m_streamInfo.push_back(streamInfo);
 
         // comb_info_Secondary_audio_Primary_audio(){
         int number_of_primary_audio_ref_entries = reader.getBits(8);  // 8 uimsbf
@@ -2596,7 +2594,8 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
         streamInfo.isSecondary = true;
         streamInfo.parseStreamEntry(reader);
         streamInfo.parseStreamAttributes(reader);
-        streamInfos.push_back(streamInfo);
+        if (PlayItem_id == 0)
+            m_streamInfo.push_back(streamInfo);
 
         // comb_info_Secondary_video_Secondary_audio(){
         int number_of_secondary_audio_ref_entries = reader.getBits(8);  // 8 uimsbf
@@ -2629,13 +2628,8 @@ void MPLSParser::STN_table(BitStreamReader& reader, int PlayItem_id)
         MPLSStreamInfo streamInfo;
         streamInfo.parseStreamEntry(reader);
         streamInfo.parseStreamAttributes(reader);
-        streamInfos.push_back(streamInfo);
-    }
-
-    if (streamInfos.size() > m_streamInfo.size())
-    {
-        m_streamInfo = std::move(streamInfos);
-        m_playItem = PlayItem_id;
+        if (PlayItem_id == 0)
+            m_streamInfo.push_back(streamInfo);
     }
 }
 

--- a/tsMuxer/tsPacket.h
+++ b/tsMuxer/tsPacket.h
@@ -529,7 +529,6 @@ struct MPLSParser
     bool is_seamless_angle_change;
 
     int m_chapterLen;
-    int m_playItem;
 
     uint32_t IN_time;
     uint32_t OUT_time;


### PR DESCRIPTION
tsMuxer currently checks the frame depth during the muxing. If a frame depth >1 is detected, the DTS (deconding time stamp) is set back during the muxing, which is wrong.

This patch allows to check and set the correct frame depth before the muxing commences.